### PR TITLE
Some updates for PR/9622

### DIFF
--- a/django/db/models/functions/math.py
+++ b/django/db/models/functions/math.py
@@ -21,33 +21,39 @@ class DecimalInputMixin:
         return clone.as_sql(compiler, connection)
 
 
+class OutputFieldMixin:
+
+    def _resolve_output_field(self):
+        sources = self.get_source_expressions()
+        if any(isinstance(s.output_field, DecimalField) for s in sources):
+            return DecimalField()
+        else:
+            return FloatField()
+
+
 class Abs(Transform):
     function = 'ABS'
     lookup_name = 'abs'
 
 
-class ACos(Transform):
+class ACos(OutputFieldMixin, Transform):
     function = 'ACOS'
     lookup_name = 'acos'
-    output_field = FloatField()
 
 
-class ASin(Transform):
+class ASin(OutputFieldMixin, Transform):
     function = 'ASIN'
     lookup_name = 'asin'
-    output_field = FloatField()
 
 
-class ATan(Transform):
+class ATan(OutputFieldMixin, Transform):
     function = 'ATAN'
     lookup_name = 'atan'
-    output_field = FloatField()
 
 
-class ATan2(Func):
+class ATan2(OutputFieldMixin, Func):
     function = 'ATAN2'
     arity = 2
-    output_field = FloatField()
 
 
 class Ceil(Transform):
@@ -58,34 +64,30 @@ class Ceil(Transform):
         return super().as_sql(compiler, connection, function='CEIL')
 
 
-class Cos(Transform):
+class Cos(OutputFieldMixin, Transform):
     function = 'COS'
     lookup_name = 'cos'
-    output_field = FloatField()
 
 
-class Cot(Transform):
+class Cot(OutputFieldMixin, Transform):
     function = 'COT'
     lookup_name = 'cot'
-    output_field = FloatField()
 
     def as_oracle(self, compiler, connection):
         return super().as_sql(compiler, connection, template='(1 / TAN(%(expressions)s))')
 
 
-class Degrees(Transform):
+class Degrees(OutputFieldMixin, Transform):
     function = 'DEGREES'
     lookup_name = 'degrees'
-    output_field = FloatField()
 
     def as_oracle(self, compiler, connection):
         return super().as_sql(compiler, connection, template='((%%(expressions)s) * 180 / %s)' % math.pi)
 
 
-class Exp(Transform):
+class Exp(OutputFieldMixin, Transform):
     function = 'EXP'
     lookup_name = 'exp'
-    output_field = FloatField()
 
 
 class Floor(Transform):
@@ -93,43 +95,37 @@ class Floor(Transform):
     lookup_name = 'floor'
 
 
-class Ln(Transform):
+class Ln(OutputFieldMixin, Transform):
     function = 'LN'
     lookup_name = 'ln'
-    output_field = FloatField()
 
 
-class Log(DecimalInputMixin, Func):
+class Log(DecimalInputMixin, OutputFieldMixin, Func):
     function = 'LOG'
     arity = 2
-    output_field = FloatField()
 
 
-class Mod(DecimalInputMixin, Func):
+class Mod(DecimalInputMixin, OutputFieldMixin, Func):
     function = 'MOD'
     arity = 2
-    output_field = FloatField()
 
 
-class Pi(Func):
+class Pi(OutputFieldMixin, Func):
     function = 'PI'
     arity = 0
-    output_field = FloatField()
 
     def as_oracle(self, compiler, connection):
         return super().as_sql(compiler, connection, template=str(math.pi))
 
 
-class Power(Func):
+class Power(OutputFieldMixin, Func):
     function = 'POWER'
     arity = 2
-    output_field = FloatField()
 
 
-class Radians(Transform):
+class Radians(OutputFieldMixin, Transform):
     function = 'RADIANS'
     lookup_name = 'radians'
-    output_field = FloatField()
 
     def as_oracle(self, compiler, connection):
         return super().as_sql(compiler, connection, template='((%%(expressions)s) * %s / 180)' % math.pi)
@@ -140,19 +136,16 @@ class Round(Transform):
     lookup_name = 'round'
 
 
-class Sin(Transform):
+class Sin(OutputFieldMixin, Transform):
     function = 'SIN'
     lookup_name = 'sin'
-    output_field = FloatField()
 
 
-class Sqrt(Transform):
+class Sqrt(OutputFieldMixin, Transform):
     function = 'SQRT'
     lookup_name = 'sqrt'
-    output_field = FloatField()
 
 
-class Tan(Transform):
+class Tan(OutputFieldMixin, Transform):
     function = 'TAN'
     lookup_name = 'tan'
-    output_field = FloatField()

--- a/tests/db_functions/math/test_abs.py
+++ b/tests/db_functions/math/test_abs.py
@@ -12,12 +12,16 @@ class AbsTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-0.8'), n2=Decimal('1.2'))
         obj = DecimalModel.objects.annotate(n1_abs=Abs('n1'), n2_abs=Abs('n2')).first()
+        self.assertIsInstance(obj.n1_abs, Decimal)
+        self.assertIsInstance(obj.n2_abs, Decimal)
         self.assertEqual(obj.n1, -obj.n1_abs)
         self.assertEqual(obj.n2, obj.n2_abs)
 
     def test_float(self):
         obj = FloatModel.objects.create(f1=-0.5, f2=12)
         obj = FloatModel.objects.annotate(f1_abs=Abs('f1'), f2_abs=Abs('f2')).first()
+        self.assertIsInstance(obj.f1_abs, float)
+        self.assertIsInstance(obj.f2_abs, float)
         self.assertEqual(obj.f1, -obj.f1_abs)
         self.assertEqual(obj.f2, obj.f2_abs)
 
@@ -28,6 +32,9 @@ class AbsTests(TestCase):
             normal_abs=Abs('normal'),
             big_abs=Abs('big'),
         ).first()
+        self.assertIsInstance(obj.small_abs, int)
+        self.assertIsInstance(obj.normal_abs, int)
+        self.assertIsInstance(obj.big_abs, int)
         self.assertEqual(obj.small, obj.small_abs)
         self.assertEqual(obj.normal, obj.normal_abs)
         self.assertEqual(obj.big, -obj.big_abs)

--- a/tests/db_functions/math/test_abs.py
+++ b/tests/db_functions/math/test_abs.py
@@ -38,6 +38,6 @@ class AbsTests(TestCase):
             DecimalModel.objects.create(n1=Decimal('-1.5'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('-0.5'), n2=Decimal('0'))
             objs = DecimalModel.objects.filter(n1__abs__gt=1)
-            self.assertQuerysetEqual(objs, [-1.5], lambda a: a.n1)
+            self.assertQuerysetEqual(objs, [Decimal('-1.5')], lambda a: a.n1)
         finally:
             DecimalField._unregister_lookup(Abs)

--- a/tests/db_functions/math/test_acos.py
+++ b/tests/db_functions/math/test_acos.py
@@ -39,6 +39,6 @@ class ACosTests(TestCase):
             DecimalModel.objects.create(n1=Decimal('0.5'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('-0.9'), n2=Decimal('0'))
             objs = DecimalModel.objects.filter(n1__acos__lt=2)
-            self.assertQuerysetEqual(objs, [0.5], lambda a: a.n1)
+            self.assertQuerysetEqual(objs, [Decimal('0.5')], lambda a: a.n1)
         finally:
             DecimalField._unregister_lookup(ACos)

--- a/tests/db_functions/math/test_acos.py
+++ b/tests/db_functions/math/test_acos.py
@@ -13,12 +13,16 @@ class ACosTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-0.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_acos=ACos('n1'), n2_acos=ACos('n2')).first()
+        self.assertIsInstance(obj.n1_acos, float)
+        self.assertIsInstance(obj.n2_acos, float)
         self.assertAlmostEqual(obj.n1_acos, math.acos(obj.n1))
         self.assertAlmostEqual(obj.n2_acos, math.acos(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-0.5, f2=0.33)
         obj = FloatModel.objects.annotate(f1_acos=ACos('f1'), f2_acos=ACos('f2')).first()
+        self.assertIsInstance(obj.f1_acos, float)
+        self.assertIsInstance(obj.f2_acos, float)
         self.assertAlmostEqual(obj.f1_acos, math.acos(obj.f1))
         self.assertAlmostEqual(obj.f2_acos, math.acos(obj.f2))
 
@@ -29,6 +33,9 @@ class ACosTests(TestCase):
             normal_acos=ACos('normal'),
             big_acos=ACos('big'),
         ).first()
+        self.assertIsInstance(obj.small_acos, float)
+        self.assertIsInstance(obj.normal_acos, float)
+        self.assertIsInstance(obj.big_acos, float)
         self.assertAlmostEqual(obj.small_acos, math.acos(obj.small))
         self.assertAlmostEqual(obj.normal_acos, math.acos(obj.normal))
         self.assertAlmostEqual(obj.big_acos, math.acos(obj.big))

--- a/tests/db_functions/math/test_acos.py
+++ b/tests/db_functions/math/test_acos.py
@@ -13,10 +13,10 @@ class ACosTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-0.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_acos=ACos('n1'), n2_acos=ACos('n2')).first()
-        self.assertIsInstance(obj.n1_acos, float)
-        self.assertIsInstance(obj.n2_acos, float)
-        self.assertAlmostEqual(obj.n1_acos, math.acos(obj.n1))
-        self.assertAlmostEqual(obj.n2_acos, math.acos(obj.n2))
+        self.assertIsInstance(obj.n1_acos, Decimal)
+        self.assertIsInstance(obj.n2_acos, Decimal)
+        self.assertAlmostEqual(obj.n1_acos, Decimal(math.acos(obj.n1)))
+        self.assertAlmostEqual(obj.n2_acos, Decimal(math.acos(obj.n2)))
 
     def test_float(self):
         FloatModel.objects.create(f1=-0.5, f2=0.33)

--- a/tests/db_functions/math/test_asin.py
+++ b/tests/db_functions/math/test_asin.py
@@ -13,10 +13,10 @@ class ASinTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('0.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_asin=ASin('n1'), n2_asin=ASin('n2')).first()
-        self.assertIsInstance(obj.n1_asin, float)
-        self.assertIsInstance(obj.n2_asin, float)
-        self.assertAlmostEqual(obj.n1_asin, math.asin(obj.n1))
-        self.assertAlmostEqual(obj.n2_asin, math.asin(obj.n2))
+        self.assertIsInstance(obj.n1_asin, Decimal)
+        self.assertIsInstance(obj.n2_asin, Decimal)
+        self.assertAlmostEqual(obj.n1_asin, Decimal(math.asin(obj.n1)))
+        self.assertAlmostEqual(obj.n2_asin, Decimal(math.asin(obj.n2)))
 
     def test_float(self):
         FloatModel.objects.create(f1=-0.5, f2=0.87)

--- a/tests/db_functions/math/test_asin.py
+++ b/tests/db_functions/math/test_asin.py
@@ -39,6 +39,6 @@ class ASinTests(TestCase):
             DecimalModel.objects.create(n1=Decimal('0.1'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('1.0'), n2=Decimal('0'))
             objs = DecimalModel.objects.filter(n1__asin__gt=1)
-            self.assertQuerysetEqual(objs, [1.0], lambda a: a.n1)
+            self.assertQuerysetEqual(objs, [Decimal('1.0')], lambda a: a.n1)
         finally:
             DecimalField._unregister_lookup(ASin)

--- a/tests/db_functions/math/test_asin.py
+++ b/tests/db_functions/math/test_asin.py
@@ -13,12 +13,16 @@ class ASinTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('0.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_asin=ASin('n1'), n2_asin=ASin('n2')).first()
+        self.assertIsInstance(obj.n1_asin, float)
+        self.assertIsInstance(obj.n2_asin, float)
         self.assertAlmostEqual(obj.n1_asin, math.asin(obj.n1))
         self.assertAlmostEqual(obj.n2_asin, math.asin(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-0.5, f2=0.87)
         obj = FloatModel.objects.annotate(f1_asin=ASin('f1'), f2_asin=ASin('f2')).first()
+        self.assertIsInstance(obj.f1_asin, float)
+        self.assertIsInstance(obj.f2_asin, float)
         self.assertAlmostEqual(obj.f1_asin, math.asin(obj.f1))
         self.assertAlmostEqual(obj.f2_asin, math.asin(obj.f2))
 
@@ -29,6 +33,9 @@ class ASinTests(TestCase):
             normal_asin=ASin('normal'),
             big_asin=ASin('big'),
         ).first()
+        self.assertIsInstance(obj.small_asin, float)
+        self.assertIsInstance(obj.normal_asin, float)
+        self.assertIsInstance(obj.big_asin, float)
         self.assertAlmostEqual(obj.small_asin, math.asin(obj.small))
         self.assertAlmostEqual(obj.normal_asin, math.asin(obj.normal))
         self.assertAlmostEqual(obj.big_asin, math.asin(obj.big))

--- a/tests/db_functions/math/test_atan.py
+++ b/tests/db_functions/math/test_atan.py
@@ -13,10 +13,10 @@ class ATanTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_atan=ATan('n1'), n2_atan=ATan('n2')).first()
-        self.assertIsInstance(obj.n1_atan, float)
-        self.assertIsInstance(obj.n2_atan, float)
-        self.assertAlmostEqual(obj.n1_atan, math.atan(obj.n1))
-        self.assertAlmostEqual(obj.n2_atan, math.atan(obj.n2))
+        self.assertIsInstance(obj.n1_atan, Decimal)
+        self.assertIsInstance(obj.n2_atan, Decimal)
+        self.assertAlmostEqual(obj.n1_atan, Decimal(math.atan(obj.n1)))
+        self.assertAlmostEqual(obj.n2_atan, Decimal(math.atan(obj.n2)))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)

--- a/tests/db_functions/math/test_atan.py
+++ b/tests/db_functions/math/test_atan.py
@@ -13,12 +13,16 @@ class ATanTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_atan=ATan('n1'), n2_atan=ATan('n2')).first()
+        self.assertIsInstance(obj.n1_atan, float)
+        self.assertIsInstance(obj.n2_atan, float)
         self.assertAlmostEqual(obj.n1_atan, math.atan(obj.n1))
         self.assertAlmostEqual(obj.n2_atan, math.atan(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)
         obj = FloatModel.objects.annotate(f1_atan=ATan('f1'), f2_atan=ATan('f2')).first()
+        self.assertIsInstance(obj.f1_atan, float)
+        self.assertIsInstance(obj.f2_atan, float)
         self.assertAlmostEqual(obj.f1_atan, math.atan(obj.f1))
         self.assertAlmostEqual(obj.f2_atan, math.atan(obj.f2))
 
@@ -29,6 +33,9 @@ class ATanTests(TestCase):
             normal_atan=ATan('normal'),
             big_atan=ATan('big'),
         ).first()
+        self.assertIsInstance(obj.small_atan, float)
+        self.assertIsInstance(obj.normal_atan, float)
+        self.assertIsInstance(obj.big_atan, float)
         self.assertAlmostEqual(obj.small_atan, math.atan(obj.small))
         self.assertAlmostEqual(obj.normal_atan, math.atan(obj.normal))
         self.assertAlmostEqual(obj.big_atan, math.atan(obj.big))

--- a/tests/db_functions/math/test_atan2.py
+++ b/tests/db_functions/math/test_atan2.py
@@ -11,13 +11,13 @@ class ATan2Tests(TestCase):
 
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-9.9'), n2=Decimal('4.6'))
-        obj = DecimalModel.objects.annotate(atan2=ATan2('n1', 'n2')).first()
-        self.assertAlmostEqual(obj.atan2, math.atan2(obj.n1, obj.n2))
+        obj = DecimalModel.objects.annotate(n_atan2=ATan2('n1', 'n2')).first()
+        self.assertAlmostEqual(obj.n_atan2, math.atan2(obj.n1, obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-25, f2=0.33)
-        obj = FloatModel.objects.annotate(atan2=ATan2('f1', 'f2')).first()
-        self.assertAlmostEqual(obj.atan2, math.atan2(obj.f1, obj.f2))
+        obj = FloatModel.objects.annotate(f_atan2=ATan2('f1', 'f2')).first()
+        self.assertAlmostEqual(obj.f_atan2, math.atan2(obj.f1, obj.f2))
 
     def test_integer(self):
         IntegerModel.objects.create(small=0, normal=1, big=10)

--- a/tests/db_functions/math/test_atan2.py
+++ b/tests/db_functions/math/test_atan2.py
@@ -12,8 +12,8 @@ class ATan2Tests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-9.9'), n2=Decimal('4.6'))
         obj = DecimalModel.objects.annotate(n_atan2=ATan2('n1', 'n2')).first()
-        self.assertIsInstance(obj.n_atan2, float)
-        self.assertAlmostEqual(obj.n_atan2, math.atan2(obj.n1, obj.n2))
+        self.assertIsInstance(obj.n_atan2, Decimal)
+        self.assertAlmostEqual(obj.n_atan2, Decimal(math.atan2(obj.n1, obj.n2)))
 
     def test_float(self):
         FloatModel.objects.create(f1=-25, f2=0.33)

--- a/tests/db_functions/math/test_atan2.py
+++ b/tests/db_functions/math/test_atan2.py
@@ -12,11 +12,13 @@ class ATan2Tests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-9.9'), n2=Decimal('4.6'))
         obj = DecimalModel.objects.annotate(n_atan2=ATan2('n1', 'n2')).first()
+        self.assertIsInstance(obj.n_atan2, float)
         self.assertAlmostEqual(obj.n_atan2, math.atan2(obj.n1, obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-25, f2=0.33)
         obj = FloatModel.objects.annotate(f_atan2=ATan2('f1', 'f2')).first()
+        self.assertIsInstance(obj.f_atan2, float)
         self.assertAlmostEqual(obj.f_atan2, math.atan2(obj.f1, obj.f2))
 
     def test_integer(self):
@@ -25,5 +27,7 @@ class ATan2Tests(TestCase):
             atan2_sn=ATan2('small', 'normal'),
             atan2_nb=ATan2('normal', 'big'),
         ).first()
+        self.assertIsInstance(obj.atan2_sn, float)
+        self.assertIsInstance(obj.atan2_nb, float)
         self.assertAlmostEqual(obj.atan2_sn, math.atan2(obj.small, obj.normal))
         self.assertAlmostEqual(obj.atan2_nb, math.atan2(obj.normal, obj.big))

--- a/tests/db_functions/math/test_ceil.py
+++ b/tests/db_functions/math/test_ceil.py
@@ -12,9 +12,9 @@ class CeilTests(TestCase):
 
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('12.9'), n2=Decimal('0.6'))
-        obj = DecimalModel.objects.annotate(n1_d=Ceil('n1'), n2_d=Ceil('n2')).first()
-        self.assertEqual(obj.n1_d, math.ceil(obj.n1))
-        self.assertEqual(obj.n2_d, math.ceil(obj.n2))
+        obj = DecimalModel.objects.annotate(n1_ceil=Ceil('n1'), n2_ceil=Ceil('n2')).first()
+        self.assertEqual(obj.n1_ceil, math.ceil(obj.n1))
+        self.assertEqual(obj.n2_ceil, math.ceil(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-12.5, f2=21.33)

--- a/tests/db_functions/math/test_ceil.py
+++ b/tests/db_functions/math/test_ceil.py
@@ -15,8 +15,8 @@ class CeilTests(TestCase):
         obj = DecimalModel.objects.annotate(n1_ceil=Ceil('n1'), n2_ceil=Ceil('n2')).first()
         self.assertIsInstance(obj.n1_ceil, Decimal)
         self.assertIsInstance(obj.n2_ceil, Decimal)
-        self.assertEqual(obj.n1_ceil, math.ceil(obj.n1))
-        self.assertEqual(obj.n2_ceil, math.ceil(obj.n2))
+        self.assertEqual(obj.n1_ceil, Decimal(math.ceil(obj.n1)))
+        self.assertEqual(obj.n2_ceil, Decimal(math.ceil(obj.n2)))
 
     def test_float(self):
         FloatModel.objects.create(f1=-12.5, f2=21.33)

--- a/tests/db_functions/math/test_ceil.py
+++ b/tests/db_functions/math/test_ceil.py
@@ -13,12 +13,16 @@ class CeilTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_ceil=Ceil('n1'), n2_ceil=Ceil('n2')).first()
+        self.assertIsInstance(obj.n1_ceil, Decimal)
+        self.assertIsInstance(obj.n2_ceil, Decimal)
         self.assertEqual(obj.n1_ceil, math.ceil(obj.n1))
         self.assertEqual(obj.n2_ceil, math.ceil(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-12.5, f2=21.33)
         obj = FloatModel.objects.annotate(f1_ceil=Ceil('f1'), f2_ceil=Ceil('f2')).first()
+        self.assertIsInstance(obj.f1_ceil, float)
+        self.assertIsInstance(obj.f2_ceil, float)
         self.assertEqual(obj.f1_ceil, math.ceil(obj.f1))
         self.assertEqual(obj.f2_ceil, math.ceil(obj.f2))
 
@@ -29,6 +33,9 @@ class CeilTests(TestCase):
             normal_ceil=Ceil('normal'),
             big_ceil=Ceil('big'),
         ).first()
+        self.assertIsInstance(obj.small_ceil, int)
+        self.assertIsInstance(obj.normal_ceil, int)
+        self.assertIsInstance(obj.big_ceil, int)
         self.assertEqual(obj.small_ceil, math.ceil(obj.small))
         self.assertEqual(obj.normal_ceil, math.ceil(obj.normal))
         self.assertEqual(obj.big_ceil, math.ceil(obj.big))

--- a/tests/db_functions/math/test_cos.py
+++ b/tests/db_functions/math/test_cos.py
@@ -13,12 +13,16 @@ class CosTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_cos=Cos('n1'), n2_cos=Cos('n2')).first()
+        self.assertIsInstance(obj.n1_cos, float)
+        self.assertIsInstance(obj.n2_cos, float)
         self.assertAlmostEqual(obj.n1_cos, math.cos(obj.n1))
         self.assertAlmostEqual(obj.n2_cos, math.cos(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)
         obj = FloatModel.objects.annotate(f1_cos=Cos('f1'), f2_cos=Cos('f2')).first()
+        self.assertIsInstance(obj.f1_cos, float)
+        self.assertIsInstance(obj.f2_cos, float)
         self.assertAlmostEqual(obj.f1_cos, math.cos(obj.f1))
         self.assertAlmostEqual(obj.f2_cos, math.cos(obj.f2))
 
@@ -29,6 +33,9 @@ class CosTests(TestCase):
             normal_cos=Cos('normal'),
             big_cos=Cos('big'),
         ).first()
+        self.assertIsInstance(obj.small_cos, float)
+        self.assertIsInstance(obj.normal_cos, float)
+        self.assertIsInstance(obj.big_cos, float)
         self.assertAlmostEqual(obj.small_cos, math.cos(obj.small))
         self.assertAlmostEqual(obj.normal_cos, math.cos(obj.normal))
         self.assertAlmostEqual(obj.big_cos, math.cos(obj.big))

--- a/tests/db_functions/math/test_cos.py
+++ b/tests/db_functions/math/test_cos.py
@@ -39,6 +39,6 @@ class CosTests(TestCase):
             DecimalModel.objects.create(n1=Decimal('-8.0'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('3.14'), n2=Decimal('0'))
             objs = DecimalModel.objects.filter(n1__cos__gt=-0.2)
-            self.assertQuerysetEqual(objs, [-8.0], lambda a: a.n1)
+            self.assertQuerysetEqual(objs, [Decimal('-8.0')], lambda a: a.n1)
         finally:
             DecimalField._unregister_lookup(Cos)

--- a/tests/db_functions/math/test_cos.py
+++ b/tests/db_functions/math/test_cos.py
@@ -13,10 +13,10 @@ class CosTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_cos=Cos('n1'), n2_cos=Cos('n2')).first()
-        self.assertIsInstance(obj.n1_cos, float)
-        self.assertIsInstance(obj.n2_cos, float)
-        self.assertAlmostEqual(obj.n1_cos, math.cos(obj.n1))
-        self.assertAlmostEqual(obj.n2_cos, math.cos(obj.n2))
+        self.assertIsInstance(obj.n1_cos, Decimal)
+        self.assertIsInstance(obj.n2_cos, Decimal)
+        self.assertAlmostEqual(obj.n1_cos, Decimal(math.cos(obj.n1)))
+        self.assertAlmostEqual(obj.n2_cos, Decimal(math.cos(obj.n2)))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)

--- a/tests/db_functions/math/test_cot.py
+++ b/tests/db_functions/math/test_cot.py
@@ -13,10 +13,10 @@ class CotTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_cot=Cot('n1'), n2_cot=Cot('n2')).first()
-        self.assertIsInstance(obj.n1_cot, float)
-        self.assertIsInstance(obj.n2_cot, float)
-        self.assertAlmostEqual(obj.n1_cot, 1 / math.tan(obj.n1))
-        self.assertAlmostEqual(obj.n2_cot, 1 / math.tan(obj.n2))
+        self.assertIsInstance(obj.n1_cot, Decimal)
+        self.assertIsInstance(obj.n2_cot, Decimal)
+        self.assertAlmostEqual(obj.n1_cot, Decimal(1 / math.tan(obj.n1)))
+        self.assertAlmostEqual(obj.n2_cot, Decimal(1 / math.tan(obj.n2)))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)

--- a/tests/db_functions/math/test_cot.py
+++ b/tests/db_functions/math/test_cot.py
@@ -39,6 +39,6 @@ class CotTests(TestCase):
             DecimalModel.objects.create(n1=Decimal('12.0'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('1.0'), n2=Decimal('0'))
             objs = DecimalModel.objects.filter(n1__cot__gt=0)
-            self.assertQuerysetEqual(objs, [1.0], lambda a: a.n1)
+            self.assertQuerysetEqual(objs, [Decimal('1.0')], lambda a: a.n1)
         finally:
             DecimalField._unregister_lookup(Cot)

--- a/tests/db_functions/math/test_cot.py
+++ b/tests/db_functions/math/test_cot.py
@@ -13,12 +13,16 @@ class CotTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_cot=Cot('n1'), n2_cot=Cot('n2')).first()
+        self.assertIsInstance(obj.n1_cot, float)
+        self.assertIsInstance(obj.n2_cot, float)
         self.assertAlmostEqual(obj.n1_cot, 1 / math.tan(obj.n1))
         self.assertAlmostEqual(obj.n2_cot, 1 / math.tan(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)
         obj = FloatModel.objects.annotate(f1_cot=Cot('f1'), f2_cot=Cot('f2')).first()
+        self.assertIsInstance(obj.f1_cot, float)
+        self.assertIsInstance(obj.f2_cot, float)
         self.assertAlmostEqual(obj.f1_cot, 1 / math.tan(obj.f1))
         self.assertAlmostEqual(obj.f2_cot, 1 / math.tan(obj.f2))
 
@@ -29,6 +33,9 @@ class CotTests(TestCase):
             normal_cot=Cot('normal'),
             big_cot=Cot('big'),
         ).first()
+        self.assertIsInstance(obj.small_cot, float)
+        self.assertIsInstance(obj.normal_cot, float)
+        self.assertIsInstance(obj.big_cot, float)
         self.assertAlmostEqual(obj.small_cot, 1 / math.tan(obj.small))
         self.assertAlmostEqual(obj.normal_cot, 1 / math.tan(obj.normal))
         self.assertAlmostEqual(obj.big_cot, 1 / math.tan(obj.big))

--- a/tests/db_functions/math/test_degrees.py
+++ b/tests/db_functions/math/test_degrees.py
@@ -13,12 +13,16 @@ class DegreesTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_degrees=Degrees('n1'), n2_degrees=Degrees('n2')).first()
+        self.assertIsInstance(obj.n1_degrees, float)
+        self.assertIsInstance(obj.n2_degrees, float)
         self.assertAlmostEqual(obj.n1_degrees, math.degrees(obj.n1))
         self.assertAlmostEqual(obj.n2_degrees, math.degrees(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)
         obj = FloatModel.objects.annotate(f1_degrees=Degrees('f1'), f2_degrees=Degrees('f2')).first()
+        self.assertIsInstance(obj.f1_degrees, float)
+        self.assertIsInstance(obj.f2_degrees, float)
         self.assertAlmostEqual(obj.f1_degrees, math.degrees(obj.f1))
         self.assertAlmostEqual(obj.f2_degrees, math.degrees(obj.f2))
 
@@ -29,6 +33,9 @@ class DegreesTests(TestCase):
             normal_degrees=Degrees('normal'),
             big_degrees=Degrees('big'),
         ).first()
+        self.assertIsInstance(obj.small_degrees, float)
+        self.assertIsInstance(obj.normal_degrees, float)
+        self.assertIsInstance(obj.big_degrees, float)
         self.assertAlmostEqual(obj.small_degrees, math.degrees(obj.small))
         self.assertAlmostEqual(obj.normal_degrees, math.degrees(obj.normal))
         self.assertAlmostEqual(obj.big_degrees, math.degrees(obj.big))

--- a/tests/db_functions/math/test_degrees.py
+++ b/tests/db_functions/math/test_degrees.py
@@ -13,10 +13,10 @@ class DegreesTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_degrees=Degrees('n1'), n2_degrees=Degrees('n2')).first()
-        self.assertIsInstance(obj.n1_degrees, float)
-        self.assertIsInstance(obj.n2_degrees, float)
-        self.assertAlmostEqual(obj.n1_degrees, math.degrees(obj.n1))
-        self.assertAlmostEqual(obj.n2_degrees, math.degrees(obj.n2))
+        self.assertIsInstance(obj.n1_degrees, Decimal)
+        self.assertIsInstance(obj.n2_degrees, Decimal)
+        self.assertAlmostEqual(obj.n1_degrees, Decimal(math.degrees(obj.n1)))
+        self.assertAlmostEqual(obj.n2_degrees, Decimal(math.degrees(obj.n2)))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)

--- a/tests/db_functions/math/test_degrees.py
+++ b/tests/db_functions/math/test_degrees.py
@@ -12,26 +12,26 @@ class DegreesTests(TestCase):
 
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
-        obj = DecimalModel.objects.annotate(n1_d=Degrees('n1'), n2_d=Degrees('n2')).first()
-        self.assertAlmostEqual(obj.n1_d, math.degrees(obj.n1))
-        self.assertAlmostEqual(obj.n2_d, math.degrees(obj.n2))
+        obj = DecimalModel.objects.annotate(n1_degrees=Degrees('n1'), n2_degrees=Degrees('n2')).first()
+        self.assertAlmostEqual(obj.n1_degrees, math.degrees(obj.n1))
+        self.assertAlmostEqual(obj.n2_degrees, math.degrees(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)
-        obj = FloatModel.objects.annotate(f1_d=Degrees('f1'), f2_d=Degrees('f2')).first()
-        self.assertAlmostEqual(obj.f1_d, math.degrees(obj.f1))
-        self.assertAlmostEqual(obj.f2_d, math.degrees(obj.f2))
+        obj = FloatModel.objects.annotate(f1_degrees=Degrees('f1'), f2_degrees=Degrees('f2')).first()
+        self.assertAlmostEqual(obj.f1_degrees, math.degrees(obj.f1))
+        self.assertAlmostEqual(obj.f2_degrees, math.degrees(obj.f2))
 
     def test_integer(self):
         IntegerModel.objects.create(small=-20, normal=15, big=-1)
         obj = IntegerModel.objects.annotate(
-            small_d=Degrees('small'),
-            normal_d=Degrees('normal'),
-            big_d=Degrees('big'),
+            small_degrees=Degrees('small'),
+            normal_degrees=Degrees('normal'),
+            big_degrees=Degrees('big'),
         ).first()
-        self.assertAlmostEqual(obj.small_d, math.degrees(obj.small))
-        self.assertAlmostEqual(obj.normal_d, math.degrees(obj.normal))
-        self.assertAlmostEqual(obj.big_d, math.degrees(obj.big))
+        self.assertAlmostEqual(obj.small_degrees, math.degrees(obj.small))
+        self.assertAlmostEqual(obj.normal_degrees, math.degrees(obj.normal))
+        self.assertAlmostEqual(obj.big_degrees, math.degrees(obj.big))
 
     def test_transform(self):
         try:

--- a/tests/db_functions/math/test_exp.py
+++ b/tests/db_functions/math/test_exp.py
@@ -39,6 +39,6 @@ class ExpTests(TestCase):
             DecimalModel.objects.create(n1=Decimal('12.0'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('-1.0'), n2=Decimal('0'))
             objs = DecimalModel.objects.filter(n1__exp__gt=10)
-            self.assertQuerysetEqual(objs, [12.0], lambda a: a.n1)
+            self.assertQuerysetEqual(objs, [Decimal('12.0')], lambda a: a.n1)
         finally:
             DecimalField._unregister_lookup(Exp)

--- a/tests/db_functions/math/test_exp.py
+++ b/tests/db_functions/math/test_exp.py
@@ -13,12 +13,16 @@ class ExpTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_exp=Exp('n1'), n2_exp=Exp('n2')).first()
+        self.assertIsInstance(obj.n1_exp, float)
+        self.assertIsInstance(obj.n2_exp, float)
         self.assertAlmostEqual(obj.n1_exp, math.exp(obj.n1))
         self.assertAlmostEqual(obj.n2_exp, math.exp(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)
         obj = FloatModel.objects.annotate(f1_exp=Exp('f1'), f2_exp=Exp('f2')).first()
+        self.assertIsInstance(obj.f1_exp, float)
+        self.assertIsInstance(obj.f2_exp, float)
         self.assertAlmostEqual(obj.f1_exp, math.exp(obj.f1))
         self.assertAlmostEqual(obj.f2_exp, math.exp(obj.f2))
 
@@ -29,6 +33,9 @@ class ExpTests(TestCase):
             normal_exp=Exp('normal'),
             big_exp=Exp('big'),
         ).first()
+        self.assertIsInstance(obj.small_exp, float)
+        self.assertIsInstance(obj.normal_exp, float)
+        self.assertIsInstance(obj.big_exp, float)
         self.assertAlmostEqual(obj.small_exp, math.exp(obj.small))
         self.assertAlmostEqual(obj.normal_exp, math.exp(obj.normal))
         self.assertAlmostEqual(obj.big_exp, math.exp(obj.big))

--- a/tests/db_functions/math/test_exp.py
+++ b/tests/db_functions/math/test_exp.py
@@ -13,10 +13,10 @@ class ExpTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_exp=Exp('n1'), n2_exp=Exp('n2')).first()
-        self.assertIsInstance(obj.n1_exp, float)
-        self.assertIsInstance(obj.n2_exp, float)
-        self.assertAlmostEqual(obj.n1_exp, math.exp(obj.n1))
-        self.assertAlmostEqual(obj.n2_exp, math.exp(obj.n2))
+        self.assertIsInstance(obj.n1_exp, Decimal)
+        self.assertIsInstance(obj.n2_exp, Decimal)
+        self.assertAlmostEqual(obj.n1_exp, Decimal(math.exp(obj.n1)))
+        self.assertAlmostEqual(obj.n2_exp, Decimal(math.exp(obj.n2)))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)

--- a/tests/db_functions/math/test_exp.py
+++ b/tests/db_functions/math/test_exp.py
@@ -12,26 +12,26 @@ class ExpTests(TestCase):
 
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
-        obj = DecimalModel.objects.annotate(n1_d=Exp('n1'), n2_d=Exp('n2')).first()
-        self.assertAlmostEqual(obj.n1_d, math.exp(obj.n1))
-        self.assertAlmostEqual(obj.n2_d, math.exp(obj.n2))
+        obj = DecimalModel.objects.annotate(n1_exp=Exp('n1'), n2_exp=Exp('n2')).first()
+        self.assertAlmostEqual(obj.n1_exp, math.exp(obj.n1))
+        self.assertAlmostEqual(obj.n2_exp, math.exp(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)
-        obj = FloatModel.objects.annotate(f1_d=Exp('f1'), f2_d=Exp('f2')).first()
-        self.assertAlmostEqual(obj.f1_d, math.exp(obj.f1))
-        self.assertAlmostEqual(obj.f2_d, math.exp(obj.f2))
+        obj = FloatModel.objects.annotate(f1_exp=Exp('f1'), f2_exp=Exp('f2')).first()
+        self.assertAlmostEqual(obj.f1_exp, math.exp(obj.f1))
+        self.assertAlmostEqual(obj.f2_exp, math.exp(obj.f2))
 
     def test_integer(self):
         IntegerModel.objects.create(small=-20, normal=15, big=-1)
         obj = IntegerModel.objects.annotate(
-            small_d=Exp('small'),
-            normal_d=Exp('normal'),
-            big_d=Exp('big'),
+            small_exp=Exp('small'),
+            normal_exp=Exp('normal'),
+            big_exp=Exp('big'),
         ).first()
-        self.assertAlmostEqual(obj.small_d, math.exp(obj.small))
-        self.assertAlmostEqual(obj.normal_d, math.exp(obj.normal))
-        self.assertAlmostEqual(obj.big_d, math.exp(obj.big))
+        self.assertAlmostEqual(obj.small_exp, math.exp(obj.small))
+        self.assertAlmostEqual(obj.normal_exp, math.exp(obj.normal))
+        self.assertAlmostEqual(obj.big_exp, math.exp(obj.big))
 
     def test_transform(self):
         try:

--- a/tests/db_functions/math/test_floor.py
+++ b/tests/db_functions/math/test_floor.py
@@ -15,8 +15,8 @@ class FloorTests(TestCase):
         obj = DecimalModel.objects.annotate(n1_floor=Floor('n1'), n2_floor=Floor('n2')).first()
         self.assertIsInstance(obj.n1_floor, Decimal)
         self.assertIsInstance(obj.n2_floor, Decimal)
-        self.assertEqual(obj.n1_floor, math.floor(obj.n1))
-        self.assertEqual(obj.n2_floor, math.floor(obj.n2))
+        self.assertEqual(obj.n1_floor, Decimal(math.floor(obj.n1)))
+        self.assertEqual(obj.n2_floor, Decimal(math.floor(obj.n2)))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)

--- a/tests/db_functions/math/test_floor.py
+++ b/tests/db_functions/math/test_floor.py
@@ -12,26 +12,26 @@ class FloorTests(TestCase):
 
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
-        obj = DecimalModel.objects.annotate(n1_d=Floor('n1'), n2_d=Floor('n2')).first()
-        self.assertEqual(obj.n1_d, math.floor(obj.n1))
-        self.assertEqual(obj.n2_d, math.floor(obj.n2))
+        obj = DecimalModel.objects.annotate(n1_floor=Floor('n1'), n2_floor=Floor('n2')).first()
+        self.assertEqual(obj.n1_floor, math.floor(obj.n1))
+        self.assertEqual(obj.n2_floor, math.floor(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)
-        obj = FloatModel.objects.annotate(f1_d=Floor('f1'), f2_d=Floor('f2')).first()
-        self.assertEqual(obj.f1_d, math.floor(obj.f1))
-        self.assertEqual(obj.f2_d, math.floor(obj.f2))
+        obj = FloatModel.objects.annotate(f1_floor=Floor('f1'), f2_floor=Floor('f2')).first()
+        self.assertEqual(obj.f1_floor, math.floor(obj.f1))
+        self.assertEqual(obj.f2_floor, math.floor(obj.f2))
 
     def test_integer(self):
         IntegerModel.objects.create(small=-20, normal=15, big=-1)
         obj = IntegerModel.objects.annotate(
-            small_d=Floor('small'),
-            normal_d=Floor('normal'),
-            big_d=Floor('big'),
+            small_floor=Floor('small'),
+            normal_floor=Floor('normal'),
+            big_floor=Floor('big'),
         ).first()
-        self.assertEqual(obj.small_d, math.floor(obj.small))
-        self.assertEqual(obj.normal_d, math.floor(obj.normal))
-        self.assertEqual(obj.big_d, math.floor(obj.big))
+        self.assertEqual(obj.small_floor, math.floor(obj.small))
+        self.assertEqual(obj.normal_floor, math.floor(obj.normal))
+        self.assertEqual(obj.big_floor, math.floor(obj.big))
 
     def test_transform(self):
         try:

--- a/tests/db_functions/math/test_floor.py
+++ b/tests/db_functions/math/test_floor.py
@@ -13,12 +13,16 @@ class FloorTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_floor=Floor('n1'), n2_floor=Floor('n2')).first()
+        self.assertIsInstance(obj.n1_floor, Decimal)
+        self.assertIsInstance(obj.n2_floor, Decimal)
         self.assertEqual(obj.n1_floor, math.floor(obj.n1))
         self.assertEqual(obj.n2_floor, math.floor(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)
         obj = FloatModel.objects.annotate(f1_floor=Floor('f1'), f2_floor=Floor('f2')).first()
+        self.assertIsInstance(obj.f1_floor, float)
+        self.assertIsInstance(obj.f2_floor, float)
         self.assertEqual(obj.f1_floor, math.floor(obj.f1))
         self.assertEqual(obj.f2_floor, math.floor(obj.f2))
 
@@ -29,6 +33,9 @@ class FloorTests(TestCase):
             normal_floor=Floor('normal'),
             big_floor=Floor('big'),
         ).first()
+        self.assertIsInstance(obj.small_floor, int)
+        self.assertIsInstance(obj.normal_floor, int)
+        self.assertIsInstance(obj.big_floor, int)
         self.assertEqual(obj.small_floor, math.floor(obj.small))
         self.assertEqual(obj.normal_floor, math.floor(obj.normal))
         self.assertEqual(obj.big_floor, math.floor(obj.big))

--- a/tests/db_functions/math/test_ln.py
+++ b/tests/db_functions/math/test_ln.py
@@ -39,6 +39,6 @@ class LnTests(TestCase):
             DecimalModel.objects.create(n1=Decimal('12.0'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('1.0'), n2=Decimal('0'))
             objs = DecimalModel.objects.filter(n1__ln__gt=0)
-            self.assertQuerysetEqual(objs, [12.0], lambda a: a.n1)
+            self.assertQuerysetEqual(objs, [Decimal('12.0')], lambda a: a.n1)
         finally:
             DecimalField._unregister_lookup(Ln)

--- a/tests/db_functions/math/test_ln.py
+++ b/tests/db_functions/math/test_ln.py
@@ -13,12 +13,16 @@ class LnTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_ln=Ln('n1'), n2_ln=Ln('n2')).first()
+        self.assertIsInstance(obj.n1_ln, float)
+        self.assertIsInstance(obj.n2_ln, float)
         self.assertAlmostEqual(obj.n1_ln, math.log(obj.n1))
         self.assertAlmostEqual(obj.n2_ln, math.log(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=27.5, f2=0.33)
         obj = FloatModel.objects.annotate(f1_ln=Ln('f1'), f2_ln=Ln('f2')).first()
+        self.assertIsInstance(obj.f1_ln, float)
+        self.assertIsInstance(obj.f2_ln, float)
         self.assertAlmostEqual(obj.f1_ln, math.log(obj.f1))
         self.assertAlmostEqual(obj.f2_ln, math.log(obj.f2))
 
@@ -29,6 +33,9 @@ class LnTests(TestCase):
             normal_ln=Ln('normal'),
             big_ln=Ln('big'),
         ).first()
+        self.assertIsInstance(obj.small_ln, float)
+        self.assertIsInstance(obj.normal_ln, float)
+        self.assertIsInstance(obj.big_ln, float)
         self.assertAlmostEqual(obj.small_ln, math.log(obj.small))
         self.assertAlmostEqual(obj.normal_ln, math.log(obj.normal))
         self.assertAlmostEqual(obj.big_ln, math.log(obj.big))

--- a/tests/db_functions/math/test_ln.py
+++ b/tests/db_functions/math/test_ln.py
@@ -12,26 +12,26 @@ class LnTests(TestCase):
 
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('12.9'), n2=Decimal('0.6'))
-        obj = DecimalModel.objects.annotate(n1_d=Ln('n1'), n2_d=Ln('n2')).first()
-        self.assertAlmostEqual(obj.n1_d, math.log(obj.n1))
-        self.assertAlmostEqual(obj.n2_d, math.log(obj.n2))
+        obj = DecimalModel.objects.annotate(n1_ln=Ln('n1'), n2_ln=Ln('n2')).first()
+        self.assertAlmostEqual(obj.n1_ln, math.log(obj.n1))
+        self.assertAlmostEqual(obj.n2_ln, math.log(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=27.5, f2=0.33)
-        obj = FloatModel.objects.annotate(f1_d=Ln('f1'), f2_d=Ln('f2')).first()
-        self.assertAlmostEqual(obj.f1_d, math.log(obj.f1))
-        self.assertAlmostEqual(obj.f2_d, math.log(obj.f2))
+        obj = FloatModel.objects.annotate(f1_ln=Ln('f1'), f2_ln=Ln('f2')).first()
+        self.assertAlmostEqual(obj.f1_ln, math.log(obj.f1))
+        self.assertAlmostEqual(obj.f2_ln, math.log(obj.f2))
 
     def test_integer(self):
         IntegerModel.objects.create(small=20, normal=15, big=1)
         obj = IntegerModel.objects.annotate(
-            small_d=Ln('small'),
-            normal_d=Ln('normal'),
-            big_d=Ln('big'),
+            small_ln=Ln('small'),
+            normal_ln=Ln('normal'),
+            big_ln=Ln('big'),
         ).first()
-        self.assertAlmostEqual(obj.small_d, math.log(obj.small))
-        self.assertAlmostEqual(obj.normal_d, math.log(obj.normal))
-        self.assertAlmostEqual(obj.big_d, math.log(obj.big))
+        self.assertAlmostEqual(obj.small_ln, math.log(obj.small))
+        self.assertAlmostEqual(obj.normal_ln, math.log(obj.normal))
+        self.assertAlmostEqual(obj.big_ln, math.log(obj.big))
 
     def test_transform(self):
         try:

--- a/tests/db_functions/math/test_ln.py
+++ b/tests/db_functions/math/test_ln.py
@@ -13,10 +13,10 @@ class LnTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_ln=Ln('n1'), n2_ln=Ln('n2')).first()
-        self.assertIsInstance(obj.n1_ln, float)
-        self.assertIsInstance(obj.n2_ln, float)
-        self.assertAlmostEqual(obj.n1_ln, math.log(obj.n1))
-        self.assertAlmostEqual(obj.n2_ln, math.log(obj.n2))
+        self.assertIsInstance(obj.n1_ln, Decimal)
+        self.assertIsInstance(obj.n2_ln, Decimal)
+        self.assertAlmostEqual(obj.n1_ln, Decimal(math.log(obj.n1)))
+        self.assertAlmostEqual(obj.n2_ln, Decimal(math.log(obj.n2)))
 
     def test_float(self):
         FloatModel.objects.create(f1=27.5, f2=0.33)

--- a/tests/db_functions/math/test_log.py
+++ b/tests/db_functions/math/test_log.py
@@ -12,11 +12,13 @@ class LogTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('12.9'), n2=Decimal('3.6'))
         obj = DecimalModel.objects.annotate(n_log=Log('n1', 'n2')).first()
+        self.assertIsInstance(obj.n_log, float)
         self.assertAlmostEqual(obj.n_log, math.log(obj.n2, obj.n1))
 
     def test_float(self):
         FloatModel.objects.create(f1=2.0, f2=4.0)
         obj = FloatModel.objects.annotate(f_log=Log('f1', 'f2')).first()
+        self.assertIsInstance(obj.f_log, float)
         self.assertAlmostEqual(obj.f_log, math.log(obj.f2, obj.f1))
 
     def test_integer(self):
@@ -26,6 +28,9 @@ class LogTests(TestCase):
             normal_log=Log('normal', 'big'),
             big_log=Log('big', 'big'),
         ).first()
+        self.assertIsInstance(obj.small_log, float)
+        self.assertIsInstance(obj.normal_log, float)
+        self.assertIsInstance(obj.big_log, float)
         self.assertAlmostEqual(obj.small_log, math.log(obj.big, obj.small))
         self.assertAlmostEqual(obj.normal_log, math.log(obj.big, obj.normal))
         self.assertAlmostEqual(obj.big_log, math.log(obj.big, obj.big))

--- a/tests/db_functions/math/test_log.py
+++ b/tests/db_functions/math/test_log.py
@@ -12,8 +12,8 @@ class LogTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('12.9'), n2=Decimal('3.6'))
         obj = DecimalModel.objects.annotate(n_log=Log('n1', 'n2')).first()
-        self.assertIsInstance(obj.n_log, float)
-        self.assertAlmostEqual(obj.n_log, math.log(obj.n2, obj.n1))
+        self.assertIsInstance(obj.n_log, Decimal)
+        self.assertAlmostEqual(obj.n_log, Decimal(math.log(obj.n2, obj.n1)))
 
     def test_float(self):
         FloatModel.objects.create(f1=2.0, f2=4.0)

--- a/tests/db_functions/math/test_mod.py
+++ b/tests/db_functions/math/test_mod.py
@@ -12,11 +12,13 @@ class ModTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-9.9'), n2=Decimal('4.6'))
         obj = DecimalModel.objects.annotate(n_mod=Mod('n1', 'n2')).first()
+        self.assertIsInstance(obj.n_mod, float)
         self.assertAlmostEqual(obj.n_mod, math.fmod(obj.n1, obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-25, f2=0.33)
         obj = FloatModel.objects.annotate(f_mod=Mod('f1', 'f2')).first()
+        self.assertIsInstance(obj.f_mod, float)
         self.assertAlmostEqual(obj.f_mod, math.fmod(obj.f1, obj.f2))
 
     def test_integer(self):
@@ -26,6 +28,9 @@ class ModTests(TestCase):
             normal_mod=Mod('normal', 'big'),
             big_mod=Mod('big', 'small'),
         ).first()
+        self.assertIsInstance(obj.small_mod, float)
+        self.assertIsInstance(obj.normal_mod, float)
+        self.assertIsInstance(obj.big_mod, float)
         self.assertEqual(obj.small_mod, math.fmod(obj.small, obj.normal))
         self.assertEqual(obj.normal_mod, math.fmod(obj.normal, obj.big))
         self.assertEqual(obj.big_mod, math.fmod(obj.big, obj.small))

--- a/tests/db_functions/math/test_mod.py
+++ b/tests/db_functions/math/test_mod.py
@@ -12,8 +12,8 @@ class ModTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-9.9'), n2=Decimal('4.6'))
         obj = DecimalModel.objects.annotate(n_mod=Mod('n1', 'n2')).first()
-        self.assertIsInstance(obj.n_mod, float)
-        self.assertAlmostEqual(obj.n_mod, math.fmod(obj.n1, obj.n2))
+        self.assertIsInstance(obj.n_mod, Decimal)
+        self.assertAlmostEqual(obj.n_mod, Decimal(math.fmod(obj.n1, obj.n2)))
 
     def test_float(self):
         FloatModel.objects.create(f1=-25, f2=0.33)

--- a/tests/db_functions/math/test_mod.py
+++ b/tests/db_functions/math/test_mod.py
@@ -11,21 +11,21 @@ class ModTests(TestCase):
 
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-9.9'), n2=Decimal('4.6'))
-        obj = DecimalModel.objects.annotate(m=Mod('n1', 'n2')).first()
-        self.assertAlmostEqual(obj.m, math.fmod(obj.n1, obj.n2))
+        obj = DecimalModel.objects.annotate(n_mod=Mod('n1', 'n2')).first()
+        self.assertAlmostEqual(obj.n_mod, math.fmod(obj.n1, obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-25, f2=0.33)
-        obj = FloatModel.objects.annotate(m=Mod('f1', 'f2')).first()
-        self.assertAlmostEqual(obj.m, math.fmod(obj.f1, obj.f2))
+        obj = FloatModel.objects.annotate(f_mod=Mod('f1', 'f2')).first()
+        self.assertAlmostEqual(obj.f_mod, math.fmod(obj.f1, obj.f2))
 
     def test_integer(self):
         IntegerModel.objects.create(small=20, normal=15, big=1)
         obj = IntegerModel.objects.annotate(
-            small_d=Mod('small', 'normal'),
-            normal_d=Mod('normal', 'big'),
-            big_d=Mod('big', 'small'),
+            small_mod=Mod('small', 'normal'),
+            normal_mod=Mod('normal', 'big'),
+            big_mod=Mod('big', 'small'),
         ).first()
-        self.assertEqual(obj.small_d, math.fmod(obj.small, obj.normal))
-        self.assertEqual(obj.normal_d, math.fmod(obj.normal, obj.big))
-        self.assertEqual(obj.big_d, math.fmod(obj.big, obj.small))
+        self.assertEqual(obj.small_mod, math.fmod(obj.small, obj.normal))
+        self.assertEqual(obj.normal_mod, math.fmod(obj.normal, obj.big))
+        self.assertEqual(obj.big_mod, math.fmod(obj.big, obj.small))

--- a/tests/db_functions/math/test_pi.py
+++ b/tests/db_functions/math/test_pi.py
@@ -11,4 +11,5 @@ class PiTests(TestCase):
     def test(self):
         FloatModel.objects.create(f1=2.5, f2=15.9)
         obj = FloatModel.objects.annotate(pi=Pi()).first()
+        self.assertIsInstance(obj.pi, float)
         self.assertAlmostEqual(obj.pi, math.pi, places=5)

--- a/tests/db_functions/math/test_power.py
+++ b/tests/db_functions/math/test_power.py
@@ -11,11 +11,13 @@ class PowerTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('1.0'), n2=Decimal('-0.6'))
         obj = DecimalModel.objects.annotate(n_power=Power('n1', 'n2')).first()
+        self.assertIsInstance(obj.n_power, float)
         self.assertAlmostEqual(obj.n_power, obj.n1 ** obj.n2)
 
     def test_float(self):
         FloatModel.objects.create(f1=2.3, f2=1.1)
         obj = FloatModel.objects.annotate(f_power=Power('f1', 'f2')).first()
+        self.assertIsInstance(obj.f_power, float)
         self.assertAlmostEqual(obj.f_power, obj.f1 ** obj.f2)
 
     def test_integer(self):
@@ -25,6 +27,9 @@ class PowerTests(TestCase):
             normal_power=Power('normal', 'big'),
             big_power=Power('big', 'small'),
         ).first()
+        self.assertIsInstance(obj.small_power, float)
+        self.assertIsInstance(obj.normal_power, float)
+        self.assertIsInstance(obj.big_power, float)
         self.assertAlmostEqual(obj.small_power, obj.small ** obj.normal)
         self.assertAlmostEqual(obj.normal_power, obj.normal ** obj.big)
         self.assertAlmostEqual(obj.big_power, obj.big ** obj.small)

--- a/tests/db_functions/math/test_power.py
+++ b/tests/db_functions/math/test_power.py
@@ -10,21 +10,21 @@ class PowerTests(TestCase):
 
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('1.0'), n2=Decimal('-0.6'))
-        obj = DecimalModel.objects.annotate(n1_d=Power('n1', 'n2')).first()
-        self.assertAlmostEqual(obj.n1_d, obj.n1 ** obj.n2)
+        obj = DecimalModel.objects.annotate(n_power=Power('n1', 'n2')).first()
+        self.assertAlmostEqual(obj.n_power, obj.n1 ** obj.n2)
 
     def test_float(self):
         FloatModel.objects.create(f1=2.3, f2=1.1)
-        obj = FloatModel.objects.annotate(f1_d=Power('f1', 'f2')).first()
-        self.assertAlmostEqual(obj.f1_d, obj.f1 ** obj.f2)
+        obj = FloatModel.objects.annotate(f_power=Power('f1', 'f2')).first()
+        self.assertAlmostEqual(obj.f_power, obj.f1 ** obj.f2)
 
     def test_integer(self):
         IntegerModel.objects.create(small=-1, normal=20, big=3)
         obj = IntegerModel.objects.annotate(
-            small_d=Power('small', 'normal'),
-            normal_d=Power('normal', 'big'),
-            big_d=Power('big', 'small'),
+            small_power=Power('small', 'normal'),
+            normal_power=Power('normal', 'big'),
+            big_power=Power('big', 'small'),
         ).first()
-        self.assertAlmostEqual(obj.small_d, obj.small ** obj.normal)
-        self.assertAlmostEqual(obj.normal_d, obj.normal ** obj.big)
-        self.assertAlmostEqual(obj.big_d, obj.big ** obj.small)
+        self.assertAlmostEqual(obj.small_power, obj.small ** obj.normal)
+        self.assertAlmostEqual(obj.normal_power, obj.normal ** obj.big)
+        self.assertAlmostEqual(obj.big_power, obj.big ** obj.small)

--- a/tests/db_functions/math/test_power.py
+++ b/tests/db_functions/math/test_power.py
@@ -11,8 +11,8 @@ class PowerTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('1.0'), n2=Decimal('-0.6'))
         obj = DecimalModel.objects.annotate(n_power=Power('n1', 'n2')).first()
-        self.assertIsInstance(obj.n_power, float)
-        self.assertAlmostEqual(obj.n_power, obj.n1 ** obj.n2)
+        self.assertIsInstance(obj.n_power, Decimal)
+        self.assertAlmostEqual(obj.n_power, Decimal(obj.n1 ** obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=2.3, f2=1.1)

--- a/tests/db_functions/math/test_radians.py
+++ b/tests/db_functions/math/test_radians.py
@@ -13,10 +13,10 @@ class RadiansTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_radians=Radians('n1'), n2_radians=Radians('n2')).first()
-        self.assertIsInstance(obj.n1_radians, float)
-        self.assertIsInstance(obj.n2_radians, float)
-        self.assertAlmostEqual(obj.n1_radians, math.radians(obj.n1))
-        self.assertAlmostEqual(obj.n2_radians, math.radians(obj.n2))
+        self.assertIsInstance(obj.n1_radians, Decimal)
+        self.assertIsInstance(obj.n2_radians, Decimal)
+        self.assertAlmostEqual(obj.n1_radians, Decimal(math.radians(obj.n1)))
+        self.assertAlmostEqual(obj.n2_radians, Decimal(math.radians(obj.n2)))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)

--- a/tests/db_functions/math/test_radians.py
+++ b/tests/db_functions/math/test_radians.py
@@ -39,6 +39,6 @@ class RadiansTests(TestCase):
             DecimalModel.objects.create(n1=Decimal('2.0'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('-1.0'), n2=Decimal('0'))
             objs = DecimalModel.objects.filter(n1__radians__gt=0)
-            self.assertQuerysetEqual(objs, [2.0], lambda a: a.n1)
+            self.assertQuerysetEqual(objs, [Decimal('2.0')], lambda a: a.n1)
         finally:
             DecimalField._unregister_lookup(Radians)

--- a/tests/db_functions/math/test_radians.py
+++ b/tests/db_functions/math/test_radians.py
@@ -13,12 +13,16 @@ class RadiansTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_radians=Radians('n1'), n2_radians=Radians('n2')).first()
+        self.assertIsInstance(obj.n1_radians, float)
+        self.assertIsInstance(obj.n2_radians, float)
         self.assertAlmostEqual(obj.n1_radians, math.radians(obj.n1))
         self.assertAlmostEqual(obj.n2_radians, math.radians(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)
         obj = FloatModel.objects.annotate(f1_radians=Radians('f1'), f2_radians=Radians('f2')).first()
+        self.assertIsInstance(obj.f1_radians, float)
+        self.assertIsInstance(obj.f2_radians, float)
         self.assertAlmostEqual(obj.f1_radians, math.radians(obj.f1))
         self.assertAlmostEqual(obj.f2_radians, math.radians(obj.f2))
 
@@ -29,6 +33,9 @@ class RadiansTests(TestCase):
             normal_radians=Radians('normal'),
             big_radians=Radians('big'),
         ).first()
+        self.assertIsInstance(obj.small_radians, float)
+        self.assertIsInstance(obj.normal_radians, float)
+        self.assertIsInstance(obj.big_radians, float)
         self.assertAlmostEqual(obj.small_radians, math.radians(obj.small))
         self.assertAlmostEqual(obj.normal_radians, math.radians(obj.normal))
         self.assertAlmostEqual(obj.big_radians, math.radians(obj.big))

--- a/tests/db_functions/math/test_radians.py
+++ b/tests/db_functions/math/test_radians.py
@@ -12,26 +12,26 @@ class RadiansTests(TestCase):
 
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
-        obj = DecimalModel.objects.annotate(n1_d=Radians('n1'), n2_d=Radians('n2')).first()
-        self.assertAlmostEqual(obj.n1_d, math.radians(obj.n1))
-        self.assertAlmostEqual(obj.n2_d, math.radians(obj.n2))
+        obj = DecimalModel.objects.annotate(n1_radians=Radians('n1'), n2_radians=Radians('n2')).first()
+        self.assertAlmostEqual(obj.n1_radians, math.radians(obj.n1))
+        self.assertAlmostEqual(obj.n2_radians, math.radians(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)
-        obj = FloatModel.objects.annotate(f1_d=Radians('f1'), f2_d=Radians('f2')).first()
-        self.assertAlmostEqual(obj.f1_d, math.radians(obj.f1))
-        self.assertAlmostEqual(obj.f2_d, math.radians(obj.f2))
+        obj = FloatModel.objects.annotate(f1_radians=Radians('f1'), f2_radians=Radians('f2')).first()
+        self.assertAlmostEqual(obj.f1_radians, math.radians(obj.f1))
+        self.assertAlmostEqual(obj.f2_radians, math.radians(obj.f2))
 
     def test_integer(self):
         IntegerModel.objects.create(small=-20, normal=15, big=-1)
         obj = IntegerModel.objects.annotate(
-            small_d=Radians('small'),
-            normal_d=Radians('normal'),
-            big_d=Radians('big'),
+            small_radians=Radians('small'),
+            normal_radians=Radians('normal'),
+            big_radians=Radians('big'),
         ).first()
-        self.assertAlmostEqual(obj.small_d, math.radians(obj.small))
-        self.assertAlmostEqual(obj.normal_d, math.radians(obj.normal))
-        self.assertAlmostEqual(obj.big_d, math.radians(obj.big))
+        self.assertAlmostEqual(obj.small_radians, math.radians(obj.small))
+        self.assertAlmostEqual(obj.normal_radians, math.radians(obj.normal))
+        self.assertAlmostEqual(obj.big_radians, math.radians(obj.big))
 
     def test_transform(self):
         try:

--- a/tests/db_functions/math/test_round.py
+++ b/tests/db_functions/math/test_round.py
@@ -1,0 +1,50 @@
+from decimal import Decimal
+
+from django.db.models import DecimalField
+from django.db.models.functions import Round
+from django.test import TestCase
+
+from ..models import DecimalModel, FloatModel, IntegerModel
+
+
+class RoundTests(TestCase):
+
+    def test_decimal(self):
+        DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
+        obj = DecimalModel.objects.annotate(n1_round=Round('n1'), n2_round=Round('n2')).first()
+        self.assertIsInstance(obj.n1_round, Decimal)
+        self.assertIsInstance(obj.n2_round, Decimal)
+        self.assertAlmostEqual(obj.n1_round, round(obj.n1))
+        self.assertAlmostEqual(obj.n2_round, round(obj.n2))
+
+    def test_float(self):
+        FloatModel.objects.create(f1=-27.5, f2=0.33)
+        obj = FloatModel.objects.annotate(f1_round=Round('f1'), f2_round=Round('f2')).first()
+        self.assertIsInstance(obj.f1_round, float)
+        self.assertIsInstance(obj.f2_round, float)
+        self.assertAlmostEqual(obj.f1_round, round(obj.f1))
+        self.assertAlmostEqual(obj.f2_round, round(obj.f2))
+
+    def test_integer(self):
+        IntegerModel.objects.create(small=-20, normal=15, big=-1)
+        obj = IntegerModel.objects.annotate(
+            small_round=Round('small'),
+            normal_round=Round('normal'),
+            big_round=Round('big'),
+        ).first()
+        self.assertIsInstance(obj.small_round, int)
+        self.assertIsInstance(obj.normal_round, int)
+        self.assertIsInstance(obj.big_round, int)
+        self.assertAlmostEqual(obj.small_round, round(obj.small))
+        self.assertAlmostEqual(obj.normal_round, round(obj.normal))
+        self.assertAlmostEqual(obj.big_round, round(obj.big))
+
+    def test_transform(self):
+        try:
+            DecimalField.register_lookup(Round)
+            DecimalModel.objects.create(n1=Decimal('2.0'), n2=Decimal('0'))
+            DecimalModel.objects.create(n1=Decimal('-1.0'), n2=Decimal('0'))
+            objs = DecimalModel.objects.filter(n1__round__gt=0)
+            self.assertQuerysetEqual(objs, [Decimal('2.0')], lambda a: a.n1)
+        finally:
+            DecimalField._unregister_lookup(Round)

--- a/tests/db_functions/math/test_sin.py
+++ b/tests/db_functions/math/test_sin.py
@@ -13,12 +13,16 @@ class SinTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_sin=Sin('n1'), n2_sin=Sin('n2')).first()
+        self.assertIsInstance(obj.n1_sin, float)
+        self.assertIsInstance(obj.n2_sin, float)
         self.assertAlmostEqual(obj.n1_sin, math.sin(obj.n1))
         self.assertAlmostEqual(obj.n2_sin, math.sin(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)
         obj = FloatModel.objects.annotate(f1_sin=Sin('f1'), f2_sin=Sin('f2')).first()
+        self.assertIsInstance(obj.f1_sin, float)
+        self.assertIsInstance(obj.f2_sin, float)
         self.assertAlmostEqual(obj.f1_sin, math.sin(obj.f1))
         self.assertAlmostEqual(obj.f2_sin, math.sin(obj.f2))
 
@@ -29,6 +33,9 @@ class SinTests(TestCase):
             normal_sin=Sin('normal'),
             big_sin=Sin('big'),
         ).first()
+        self.assertIsInstance(obj.small_sin, float)
+        self.assertIsInstance(obj.normal_sin, float)
+        self.assertIsInstance(obj.big_sin, float)
         self.assertAlmostEqual(obj.small_sin, math.sin(obj.small))
         self.assertAlmostEqual(obj.normal_sin, math.sin(obj.normal))
         self.assertAlmostEqual(obj.big_sin, math.sin(obj.big))

--- a/tests/db_functions/math/test_sin.py
+++ b/tests/db_functions/math/test_sin.py
@@ -12,26 +12,26 @@ class SinTests(TestCase):
 
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
-        obj = DecimalModel.objects.annotate(n1_d=Sin('n1'), n2_d=Sin('n2')).first()
-        self.assertAlmostEqual(obj.n1_d, math.sin(obj.n1))
-        self.assertAlmostEqual(obj.n2_d, math.sin(obj.n2))
+        obj = DecimalModel.objects.annotate(n1_sin=Sin('n1'), n2_sin=Sin('n2')).first()
+        self.assertAlmostEqual(obj.n1_sin, math.sin(obj.n1))
+        self.assertAlmostEqual(obj.n2_sin, math.sin(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)
-        obj = FloatModel.objects.annotate(f1_d=Sin('f1'), f2_d=Sin('f2')).first()
-        self.assertAlmostEqual(obj.f1_d, math.sin(obj.f1))
-        self.assertAlmostEqual(obj.f2_d, math.sin(obj.f2))
+        obj = FloatModel.objects.annotate(f1_sin=Sin('f1'), f2_sin=Sin('f2')).first()
+        self.assertAlmostEqual(obj.f1_sin, math.sin(obj.f1))
+        self.assertAlmostEqual(obj.f2_sin, math.sin(obj.f2))
 
     def test_integer(self):
         IntegerModel.objects.create(small=-20, normal=15, big=-1)
         obj = IntegerModel.objects.annotate(
-            small_d=Sin('small'),
-            normal_d=Sin('normal'),
-            big_d=Sin('big'),
+            small_sin=Sin('small'),
+            normal_sin=Sin('normal'),
+            big_sin=Sin('big'),
         ).first()
-        self.assertAlmostEqual(obj.small_d, math.sin(obj.small))
-        self.assertAlmostEqual(obj.normal_d, math.sin(obj.normal))
-        self.assertAlmostEqual(obj.big_d, math.sin(obj.big))
+        self.assertAlmostEqual(obj.small_sin, math.sin(obj.small))
+        self.assertAlmostEqual(obj.normal_sin, math.sin(obj.normal))
+        self.assertAlmostEqual(obj.big_sin, math.sin(obj.big))
 
     def test_transform(self):
         try:

--- a/tests/db_functions/math/test_sin.py
+++ b/tests/db_functions/math/test_sin.py
@@ -13,10 +13,10 @@ class SinTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_sin=Sin('n1'), n2_sin=Sin('n2')).first()
-        self.assertIsInstance(obj.n1_sin, float)
-        self.assertIsInstance(obj.n2_sin, float)
-        self.assertAlmostEqual(obj.n1_sin, math.sin(obj.n1))
-        self.assertAlmostEqual(obj.n2_sin, math.sin(obj.n2))
+        self.assertIsInstance(obj.n1_sin, Decimal)
+        self.assertIsInstance(obj.n2_sin, Decimal)
+        self.assertAlmostEqual(obj.n1_sin, Decimal(math.sin(obj.n1)))
+        self.assertAlmostEqual(obj.n2_sin, Decimal(math.sin(obj.n2)))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)

--- a/tests/db_functions/math/test_sqrt.py
+++ b/tests/db_functions/math/test_sqrt.py
@@ -39,6 +39,6 @@ class SqrtTests(TestCase):
             DecimalModel.objects.create(n1=Decimal('6.0'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('1.0'), n2=Decimal('0'))
             objs = DecimalModel.objects.filter(n1__sqrt__gt=2)
-            self.assertQuerysetEqual(objs, [6.0], lambda a: a.n1)
+            self.assertQuerysetEqual(objs, [Decimal('6.0')], lambda a: a.n1)
         finally:
             DecimalField._unregister_lookup(Sqrt)

--- a/tests/db_functions/math/test_sqrt.py
+++ b/tests/db_functions/math/test_sqrt.py
@@ -13,12 +13,16 @@ class SqrtTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_sqrt=Sqrt('n1'), n2_sqrt=Sqrt('n2')).first()
+        self.assertIsInstance(obj.n1_sqrt, float)
+        self.assertIsInstance(obj.n2_sqrt, float)
         self.assertAlmostEqual(obj.n1_sqrt, math.sqrt(obj.n1))
         self.assertAlmostEqual(obj.n2_sqrt, math.sqrt(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=27.5, f2=0.33)
         obj = FloatModel.objects.annotate(f1_sqrt=Sqrt('f1'), f2_sqrt=Sqrt('f2')).first()
+        self.assertIsInstance(obj.f1_sqrt, float)
+        self.assertIsInstance(obj.f2_sqrt, float)
         self.assertAlmostEqual(obj.f1_sqrt, math.sqrt(obj.f1))
         self.assertAlmostEqual(obj.f2_sqrt, math.sqrt(obj.f2))
 
@@ -29,6 +33,9 @@ class SqrtTests(TestCase):
             normal_sqrt=Sqrt('normal'),
             big_sqrt=Sqrt('big'),
         ).first()
+        self.assertIsInstance(obj.small_sqrt, float)
+        self.assertIsInstance(obj.normal_sqrt, float)
+        self.assertIsInstance(obj.big_sqrt, float)
         self.assertAlmostEqual(obj.small_sqrt, math.sqrt(obj.small))
         self.assertAlmostEqual(obj.normal_sqrt, math.sqrt(obj.normal))
         self.assertAlmostEqual(obj.big_sqrt, math.sqrt(obj.big))

--- a/tests/db_functions/math/test_sqrt.py
+++ b/tests/db_functions/math/test_sqrt.py
@@ -13,10 +13,10 @@ class SqrtTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_sqrt=Sqrt('n1'), n2_sqrt=Sqrt('n2')).first()
-        self.assertIsInstance(obj.n1_sqrt, float)
-        self.assertIsInstance(obj.n2_sqrt, float)
-        self.assertAlmostEqual(obj.n1_sqrt, math.sqrt(obj.n1))
-        self.assertAlmostEqual(obj.n2_sqrt, math.sqrt(obj.n2))
+        self.assertIsInstance(obj.n1_sqrt, Decimal)
+        self.assertIsInstance(obj.n2_sqrt, Decimal)
+        self.assertAlmostEqual(obj.n1_sqrt, Decimal(math.sqrt(obj.n1)))
+        self.assertAlmostEqual(obj.n2_sqrt, Decimal(math.sqrt(obj.n2)))
 
     def test_float(self):
         FloatModel.objects.create(f1=27.5, f2=0.33)

--- a/tests/db_functions/math/test_sqrt.py
+++ b/tests/db_functions/math/test_sqrt.py
@@ -12,26 +12,26 @@ class SqrtTests(TestCase):
 
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('12.9'), n2=Decimal('0.6'))
-        obj = DecimalModel.objects.annotate(n1_d=Sqrt('n1'), n2_d=Sqrt('n2')).first()
-        self.assertAlmostEqual(obj.n1_d, math.sqrt(obj.n1))
-        self.assertAlmostEqual(obj.n2_d, math.sqrt(obj.n2))
+        obj = DecimalModel.objects.annotate(n1_sqrt=Sqrt('n1'), n2_sqrt=Sqrt('n2')).first()
+        self.assertAlmostEqual(obj.n1_sqrt, math.sqrt(obj.n1))
+        self.assertAlmostEqual(obj.n2_sqrt, math.sqrt(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=27.5, f2=0.33)
-        obj = FloatModel.objects.annotate(f1_d=Sqrt('f1'), f2_d=Sqrt('f2')).first()
-        self.assertAlmostEqual(obj.f1_d, math.sqrt(obj.f1))
-        self.assertAlmostEqual(obj.f2_d, math.sqrt(obj.f2))
+        obj = FloatModel.objects.annotate(f1_sqrt=Sqrt('f1'), f2_sqrt=Sqrt('f2')).first()
+        self.assertAlmostEqual(obj.f1_sqrt, math.sqrt(obj.f1))
+        self.assertAlmostEqual(obj.f2_sqrt, math.sqrt(obj.f2))
 
     def test_integer(self):
         IntegerModel.objects.create(small=20, normal=15, big=1)
         obj = IntegerModel.objects.annotate(
-            small_d=Sqrt('small'),
-            normal_d=Sqrt('normal'),
-            big_d=Sqrt('big'),
+            small_sqrt=Sqrt('small'),
+            normal_sqrt=Sqrt('normal'),
+            big_sqrt=Sqrt('big'),
         ).first()
-        self.assertAlmostEqual(obj.small_d, math.sqrt(obj.small))
-        self.assertAlmostEqual(obj.normal_d, math.sqrt(obj.normal))
-        self.assertAlmostEqual(obj.big_d, math.sqrt(obj.big))
+        self.assertAlmostEqual(obj.small_sqrt, math.sqrt(obj.small))
+        self.assertAlmostEqual(obj.normal_sqrt, math.sqrt(obj.normal))
+        self.assertAlmostEqual(obj.big_sqrt, math.sqrt(obj.big))
 
     def test_transform(self):
         try:

--- a/tests/db_functions/math/test_tan.py
+++ b/tests/db_functions/math/test_tan.py
@@ -39,6 +39,6 @@ class TanTests(TestCase):
             DecimalModel.objects.create(n1=Decimal('0.0'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('12.0'), n2=Decimal('0'))
             objs = DecimalModel.objects.filter(n1__tan__lt=0)
-            self.assertQuerysetEqual(objs, [12.0], lambda a: a.n1)
+            self.assertQuerysetEqual(objs, [Decimal('12.0')], lambda a: a.n1)
         finally:
             DecimalField._unregister_lookup(Tan)

--- a/tests/db_functions/math/test_tan.py
+++ b/tests/db_functions/math/test_tan.py
@@ -13,12 +13,16 @@ class TanTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_tan=Tan('n1'), n2_tan=Tan('n2')).first()
+        self.assertIsInstance(obj.n1_tan, float)
+        self.assertIsInstance(obj.n2_tan, float)
         self.assertAlmostEqual(obj.n1_tan, math.tan(obj.n1))
         self.assertAlmostEqual(obj.n2_tan, math.tan(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)
         obj = FloatModel.objects.annotate(f1_tan=Tan('f1'), f2_tan=Tan('f2')).first()
+        self.assertIsInstance(obj.f1_tan, float)
+        self.assertIsInstance(obj.f2_tan, float)
         self.assertAlmostEqual(obj.f1_tan, math.tan(obj.f1))
         self.assertAlmostEqual(obj.f2_tan, math.tan(obj.f2))
 
@@ -29,6 +33,9 @@ class TanTests(TestCase):
             normal_tan=Tan('normal'),
             big_tan=Tan('big'),
         ).first()
+        self.assertIsInstance(obj.small_tan, float)
+        self.assertIsInstance(obj.normal_tan, float)
+        self.assertIsInstance(obj.big_tan, float)
         self.assertAlmostEqual(obj.small_tan, math.tan(obj.small))
         self.assertAlmostEqual(obj.normal_tan, math.tan(obj.normal))
         self.assertAlmostEqual(obj.big_tan, math.tan(obj.big))

--- a/tests/db_functions/math/test_tan.py
+++ b/tests/db_functions/math/test_tan.py
@@ -13,10 +13,10 @@ class TanTests(TestCase):
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
         obj = DecimalModel.objects.annotate(n1_tan=Tan('n1'), n2_tan=Tan('n2')).first()
-        self.assertIsInstance(obj.n1_tan, float)
-        self.assertIsInstance(obj.n2_tan, float)
-        self.assertAlmostEqual(obj.n1_tan, math.tan(obj.n1))
-        self.assertAlmostEqual(obj.n2_tan, math.tan(obj.n2))
+        self.assertIsInstance(obj.n1_tan, Decimal)
+        self.assertIsInstance(obj.n2_tan, Decimal)
+        self.assertAlmostEqual(obj.n1_tan, Decimal(math.tan(obj.n1)))
+        self.assertAlmostEqual(obj.n2_tan, Decimal(math.tan(obj.n2)))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)

--- a/tests/db_functions/math/test_tan.py
+++ b/tests/db_functions/math/test_tan.py
@@ -12,26 +12,26 @@ class TanTests(TestCase):
 
     def test_decimal(self):
         DecimalModel.objects.create(n1=Decimal('-12.9'), n2=Decimal('0.6'))
-        obj = DecimalModel.objects.annotate(n1_d=Tan('n1'), n2_d=Tan('n2')).first()
-        self.assertAlmostEqual(obj.n1_d, math.tan(obj.n1))
-        self.assertAlmostEqual(obj.n2_d, math.tan(obj.n2))
+        obj = DecimalModel.objects.annotate(n1_tan=Tan('n1'), n2_tan=Tan('n2')).first()
+        self.assertAlmostEqual(obj.n1_tan, math.tan(obj.n1))
+        self.assertAlmostEqual(obj.n2_tan, math.tan(obj.n2))
 
     def test_float(self):
         FloatModel.objects.create(f1=-27.5, f2=0.33)
-        obj = FloatModel.objects.annotate(f1_d=Tan('f1'), f2_d=Tan('f2')).first()
-        self.assertAlmostEqual(obj.f1_d, math.tan(obj.f1))
-        self.assertAlmostEqual(obj.f2_d, math.tan(obj.f2))
+        obj = FloatModel.objects.annotate(f1_tan=Tan('f1'), f2_tan=Tan('f2')).first()
+        self.assertAlmostEqual(obj.f1_tan, math.tan(obj.f1))
+        self.assertAlmostEqual(obj.f2_tan, math.tan(obj.f2))
 
     def test_integer(self):
         IntegerModel.objects.create(small=-20, normal=15, big=-1)
         obj = IntegerModel.objects.annotate(
-            small_d=Tan('small'),
-            normal_d=Tan('normal'),
-            big_d=Tan('big'),
+            small_tan=Tan('small'),
+            normal_tan=Tan('normal'),
+            big_tan=Tan('big'),
         ).first()
-        self.assertAlmostEqual(obj.small_d, math.tan(obj.small))
-        self.assertAlmostEqual(obj.normal_d, math.tan(obj.normal))
-        self.assertAlmostEqual(obj.big_d, math.tan(obj.big))
+        self.assertAlmostEqual(obj.small_tan, math.tan(obj.small))
+        self.assertAlmostEqual(obj.normal_tan, math.tan(obj.normal))
+        self.assertAlmostEqual(obj.big_tan, math.tan(obj.big))
 
     def test_transform(self):
         try:


### PR DESCRIPTION
Hi @JunyiJ,

I've made a number of fixes that you can pull into your branch:

- Simplified the type casting for `Log()` and `Mod()` on PostgreSQL.
  *(The issue was that a value is needed for `max_digits` and `decimal_places`.)*
- We no longer cast `DecimalField` to `FloatField` for `output_field`.
- Added type assertions to tests to complement the `output_field` stuff.
- Added missing tests for `Round()`.
- Fixed the problem with `Log()` on the SpatiaLite backend.
- Various other bits of tidying in the tests.

I've noted that `ATAN2` was added to SpatiaLite v4.3.0 which also seems to exhibit problems but I think Django's Jenkins currently uses < v4.3.0, so `math.atan2` is still being used.

See http://www.gaia-gis.it/gaia-sins/spatialite-sql-4.3.0.html#math

Bug filed for Log() on SpatiaLite: https://www.gaia-gis.it/fossil/libspatialite/tktview?name=8f59ddebf0